### PR TITLE
[TR] PIM-5219: Include database name into entity references

### DIFF
--- a/Normalizer/ProductValueNormalizer.php
+++ b/Normalizer/ProductValueNormalizer.php
@@ -47,13 +47,14 @@ class ProductValueNormalizer extends BaseProductValueNormalizer
             throw new \LogicException('Serializer must be a normalizer');
         }
 
-        $productId = $context[ProductNormalizer::MONGO_ID];
         $productCollection = $context[ProductNormalizer::MONGO_COLLECTION_NAME];
+        $productId = $context[ProductNormalizer::MONGO_ID];
+        $databaseName = $context[ProductNormalizer::MONGO_DATABASE_NAME];
 
         $data = [];
         $data['_id'] = $this->mongoFactory->createMongoId();
         $data['attribute'] = $value->getAttribute()->getId();
-        $data['entity'] = $this->mongoFactory->createMongoDBRef($productCollection, $productId);
+        $data['entity'] = $this->mongoFactory->createMongoDBRef($productCollection, $productId, $databaseName);
 
         if (null !== $value->getLocale()) {
             $data['locale'] = $value->getLocale();

--- a/Resources/config/storage_driver/doctrine/mongodb-odm.yml
+++ b/Resources/config/storage_driver/doctrine/mongodb-odm.yml
@@ -28,6 +28,7 @@ services:
             - '@pim_serializer'
             - '@pim_catalog.mongodb.mongo_objects_factory'
             - %pim_catalog.entity.product.class%
+            - %mongodb_database%
 
     pim_catalog.saver.group:
         class: %pim_direct_to_mongodb.saver.group.class%

--- a/Saver/ProductSaver.php
+++ b/Saver/ProductSaver.php
@@ -7,6 +7,7 @@ use Akeneo\Component\StorageUtils\Saver\SavingOptionsResolverInterface;
 use Akeneo\Component\StorageUtils\StorageEvents;
 use Doctrine\Common\Persistence\ObjectManager;
 use Doctrine\Common\Util\ClassUtils;
+use Doctrine\MongoDB\Collection;
 use Pim\Bundle\CatalogBundle\Doctrine\Common\Saver\ProductSaver as BaseProductSaver;
 use Pim\Bundle\CatalogBundle\Manager\CompletenessManager;
 use Pim\Bundle\CatalogBundle\Model\ProductInterface;
@@ -40,6 +41,9 @@ class ProductSaver extends BaseProductSaver
     /** @var string */
     protected $productClass;
 
+    /** @var string */
+    protected $databaseName;
+
     /** @var Collection */
     protected $collection;
 
@@ -52,6 +56,7 @@ class ProductSaver extends BaseProductSaver
      * @param NormalizerInterface            $normalizer
      * @param MongoObjectsFactory            $mongoFactory
      * @param string                         $productClass
+     * @param string                         $databaseName
      */
     public function __construct(
         ObjectManager $om,
@@ -61,7 +66,8 @@ class ProductSaver extends BaseProductSaver
         BulkVersionPersister $versionPersister,
         NormalizerInterface $normalizer,
         MongoObjectsFactory $mongoFactory,
-        $productClass
+        $productClass,
+        $databaseName
     ) {
         parent::__construct($om, $completenessManager, $optionsResolver, $eventDispatcher);
 
@@ -69,6 +75,7 @@ class ProductSaver extends BaseProductSaver
         $this->normalizer       = $normalizer;
         $this->mongoFactory     = $mongoFactory;
         $this->productClass     = $productClass;
+        $this->databaseName     = $databaseName;
     }
 
     /**
@@ -127,7 +134,10 @@ class ProductSaver extends BaseProductSaver
      */
     protected function getDocsFromProducts(array $products)
     {
-        $context = [ProductNormalizer::MONGO_COLLECTION_NAME => $this->collection->getName()];
+        $context = [
+            ProductNormalizer::MONGO_COLLECTION_NAME => $this->collection->getName(),
+            ProductNormalizer::MONGO_DATABASE_NAME   => $this->databaseName
+        ];
 
         $docs = [];
         foreach ($products as $product) {


### PR DESCRIPTION
In order to respect the ODM format we need to add database name into entity references of product values.
To achieve that :
1. database name parameter is injected into the saver
2. it is passed to the normalization via the context
3. the ProductValueNormalizer uses it to create the entity references
